### PR TITLE
Allow custom annotations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "kubernetes_deployment" "external_dns" {
     template {
       metadata {
         labels = local.kubernetes_deployment_labels
+        annotations = var.kubernetes_deployment_annotations
       }
 
       spec {

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,9 @@ variable "aws_iam_role_for_policy" {
   default = null
   description = "AWS role name for attaching IAM policy"
 }
+
+variable "kubernetes_deployment_annotations" {
+  type = map(string)
+  default = {}
+  description = "Annotations for pod template"
+}


### PR DESCRIPTION
The use case behind this is to allow for the "iam.amazonaws.com/role" annotation, so that kube2iam can assign the correct role to the pod